### PR TITLE
Enabled C# 6, fixed MP performance, added update checks

### DIFF
--- a/kRPG/API.cs
+++ b/kRPG/API.cs
@@ -248,7 +248,7 @@ namespace kRPG
                 }
                 if (item.type >= 1803 && item.type <= 1807)
                 {
-                    item.SetDefaults(1533 + item.type - 1803, false);
+                    item.SetDefaults(1533 + item.type - 1803, true);
                 }
                 if (item.dye > 0)
                 {

--- a/kRPG/Items/ProceduralItem.cs
+++ b/kRPG/Items/ProceduralItem.cs
@@ -238,7 +238,7 @@ namespace kRPG.Items
         {
             if (texture == null)
             {
-                item.SetDefaults(0);
+                item.SetDefaults(0,true);
             }
             spriteBatch.Draw(texture, position, null, color, rotation, Vector2.Zero, scale, SpriteEffects.None, 0f);
         }
@@ -249,7 +249,7 @@ namespace kRPG.Items
             Vector2 position = new Vector2(4f * player.direction, -4f).RotatedBy(rotation) + playerCenter;
             if (texture == null)
             {
-                item.SetDefaults(0);
+                item.SetDefaults(0,true);
             }
             SpriteEffects effects = player.direction > 0 ? SpriteEffects.None : SpriteEffects.FlipHorizontally;
             DrawData draw = new DrawData(texture, position, null, color, rotation, new Vector2(player.direction > 0 ? 0 : texture.Width, texture.Height), scale, effects, 0);
@@ -340,19 +340,8 @@ namespace kRPG.Items
             }
         }
 
-        public bool? OverhaulHasTag(string tag)
-        {
-            if (tag == "magicstaff")
-            {
-                return true;
-            }
-            return null;
-        }
-
-        public Texture2D OverhaulGetTexture()
-        {
-            return texture;
-        }
+        public bool? OverhaulHasTag(string tag)	=> tag=="magicWeapon" ? (bool?)true : null;
+        public Texture2D OverhaulGetTexture()	=> texture;
 
         public override void ModifyTooltips(List<TooltipLine> tooltips)
         {
@@ -601,7 +590,7 @@ namespace kRPG.Items
         {
             if (texture == null)
             {
-                item.SetDefaults(0);
+                item.SetDefaults(0,true);
                 return;
             }
             spriteBatch.Draw(texture, position, null, lighted ? Color.White : color, rotation, Vector2.Zero, scale, SpriteEffects.None, 0f);
@@ -707,21 +696,7 @@ namespace kRPG.Items
             }
         }
 
-        public bool? OverhaulHasTag(string tag)
-        {
-            if (spear)
-            { 
-                if (tag == "spear")
-                    return true;
-            }
-            else if (tag == "broadsword")
-                return true;
-            return null;
-        }
-
-        public Texture2D OverhaulGetTexture()
-        {
-            return texture;
-        }
+        public bool? OverhaulHasTag(string tag)	=> (spear ? tag=="spear" : tag=="broadsword") ? (bool?)true : null;
+        public Texture2D OverhaulGetTexture()	=> texture;
     }
 }

--- a/kRPG/Items/kItem.cs
+++ b/kRPG/Items/kItem.cs
@@ -1059,7 +1059,7 @@ namespace kRPG.Items
         public void Destroy(Item item)
         {
             Main.NewText("Failed to upgrade - item was destroyed", 255, 0, 0);
-            item.SetDefaults(0);
+            item.SetDefaults(0,true);
         }
 
         public bool Upgradeable(Item item)

--- a/kRPG/NPCs/RetiredAdventurer.cs
+++ b/kRPG/NPCs/RetiredAdventurer.cs
@@ -61,10 +61,10 @@ namespace kRPG.NPCs
 
         public override void SetupShop(Chest shop, ref int nextSlot)
         {
-            shop.item[nextSlot++].SetDefaults(mod.ItemType<ScintillatingBloodLacrima>());
-            shop.item[nextSlot++].SetDefaults(mod.ItemType<EyeOnAStick>());
-            shop.item[nextSlot++].SetDefaults(mod.ItemType<Scythe>());
-            shop.item[nextSlot++].SetDefaults(mod.ItemType<Arbalest>());
+            shop.item[nextSlot++].SetDefaults(mod.ItemType<ScintillatingBloodLacrima>(),true);
+            shop.item[nextSlot++].SetDefaults(mod.ItemType<EyeOnAStick>(),true);
+            shop.item[nextSlot++].SetDefaults(mod.ItemType<Scythe>(),true);
+            shop.item[nextSlot++].SetDefaults(mod.ItemType<Arbalest>(),true);
         }
 
         public override string TownNPCName()

--- a/kRPG/PlayerCharacter.cs
+++ b/kRPG/PlayerCharacter.cs
@@ -189,7 +189,7 @@ namespace kRPG
                 for (int j = 0; j < abilities[i].glyphs.Length; j += 1)
                 {
                     abilities[i].glyphs[j] = new Item();
-                    abilities[i].glyphs[j].SetDefaults();
+                    abilities[i].glyphs[j].SetDefaults(0,true);
                 }
             }
             abilities[0].key = Keys.Z;
@@ -204,7 +204,7 @@ namespace kRPG
                 for (int j = 0; j < inventories[i].Length; j += 1)
                 {
                     inventories[i][j] = new Item();
-                    inventories[i][j].SetDefaults();
+                    inventories[i][j].SetDefaults(0,true);
                 }
             }
         }
@@ -215,60 +215,60 @@ namespace kRPG
             switch (rand.Next(8))
             {
                 default:
-                    items[0].SetDefaults(rand.Next(2) == 0 ? ItemID.TinBroadsword : ItemID.CopperBroadsword);
+                    items[0].SetDefaults(rand.Next(2) == 0 ? ItemID.TinBroadsword : ItemID.CopperBroadsword,true);
                     break;
                 case 1:
-                    items[0].SetDefaults(ItemID.Spear);
+                    items[0].SetDefaults(ItemID.Spear,true);
                     break;
                 case 2:
-                    items[0].SetDefaults(ItemID.WoodenBoomerang);
+                    items[0].SetDefaults(ItemID.WoodenBoomerang,true);
                     break;
                 case 3:
-                    items[0].SetDefaults(rand.Next(2) == 0 ? ItemID.TopazStaff : ItemID.AmethystStaff);
+                    items[0].SetDefaults(rand.Next(2) == 0 ? ItemID.TopazStaff : ItemID.AmethystStaff,true);
                     break;
                 case 4:
-                    items[0].SetDefaults(rand.Next(2) == 0 ? ItemID.TinBow : ItemID.CopperBow);
+                    items[0].SetDefaults(rand.Next(2) == 0 ? ItemID.TinBow : ItemID.CopperBow,true);
                     Item arrows = new Item();
-                    arrows.SetDefaults(rand.Next(2) == 0 ? ItemID.FlamingArrow : ItemID.WoodenArrow);
+                    arrows.SetDefaults(rand.Next(2) == 0 ? ItemID.FlamingArrow : ItemID.WoodenArrow,true);
                     arrows.stack = rand.Next(2) == 0 ? 150 : 200;
                     items.Add(arrows);
                     break;
                 case 5:
-                    items[0].SetDefaults(ItemID.Shuriken);
+                    items[0].SetDefaults(ItemID.Shuriken,true);
                     items[0].stack = rand.Next(2) == 0 ? 150 : 100;
                     Item knives = new Item();
-                    knives.SetDefaults(rand.Next(2) == 0 ? ItemID.PoisonedKnife : ItemID.ThrowingKnife);
+                    knives.SetDefaults(rand.Next(2) == 0 ? ItemID.PoisonedKnife : ItemID.ThrowingKnife,true);
                     knives.stack = 50;
                     items.Add(knives);
                     break;
                 case 6:
-                    items[0].SetDefaults(ItemID.WoodYoyo);
+                    items[0].SetDefaults(ItemID.WoodYoyo,true);
                     break;
                 case 7:
-                    items[0].SetDefaults(ItemID.ChainKnife);
+                    items[0].SetDefaults(ItemID.ChainKnife,true);
                     break;
             }
-            items[1].SetDefaults(rand.Next(3) == 0 ? ItemID.TinPickaxe : rand.Next(2) == 0 ? ItemID.CactusPickaxe : ItemID.CopperPickaxe);
+            items[1].SetDefaults(rand.Next(3) == 0 ? ItemID.TinPickaxe : rand.Next(2) == 0 ? ItemID.CactusPickaxe : ItemID.CopperPickaxe,true);
             items[1].GetGlobalItem<kItem>().Initialize(items[1], true);
             items[2].SetDefaults(rand.Next(2) == 0 ? ItemID.TinAxe : ItemID.CopperAxe);
-            items[2].GetGlobalItem<kItem>().Initialize(items[2], true);
+            items[2].GetGlobalItem<kItem>().Initialize(items[2],true);
 
             Item star = new Item();
-            star.SetDefaults(mod.ItemType<Star_Blue>());
+            star.SetDefaults(mod.ItemType<Star_Blue>(),true);
             Item cross = new Item();
             switch (rand.Next(4))
             {
                 default:
-                    cross.SetDefaults(mod.ItemType<Cross_Red>());
+                    cross.SetDefaults(mod.ItemType<Cross_Red>(),true);
                     break;
                 case 1:
-                    cross.SetDefaults(mod.ItemType<Cross_Orange>());
+                    cross.SetDefaults(mod.ItemType<Cross_Orange>(),true);
                     break;
                 case 2:
-                    cross.SetDefaults(mod.ItemType<Cross_Yellow>());
+                    cross.SetDefaults(mod.ItemType<Cross_Yellow>(),true);
                     break;
                 case 3:
-                    cross.SetDefaults(mod.ItemType<Cross_Green>());
+                    cross.SetDefaults(mod.ItemType<Cross_Green>(),true);
                     break;
             }
             ((Glyph)cross.modItem).Randomize();
@@ -276,19 +276,19 @@ namespace kRPG
             switch (rand.Next(5))
             {
                 default:
-                    moon.SetDefaults(mod.ItemType<Moon_Yellow>());
+                    moon.SetDefaults(mod.ItemType<Moon_Yellow>(),true);
                     break;
                 case 1:
-                    moon.SetDefaults(mod.ItemType<Moon_Green>());
+                    moon.SetDefaults(mod.ItemType<Moon_Green>(),true);
                     break;
                 case 2:
-                    moon.SetDefaults(mod.ItemType<Moon_Blue>());
+                    moon.SetDefaults(mod.ItemType<Moon_Blue>(),true);
                     break;
                 case 3:
-                    moon.SetDefaults(mod.ItemType<Moon_Violet>());
+                    moon.SetDefaults(mod.ItemType<Moon_Violet>(),true);
                     break;
                 case 4:
-                    moon.SetDefaults(mod.ItemType<Moon_Purple>());
+                    moon.SetDefaults(mod.ItemType<Moon_Purple>(),true);
                     break;
             }
             ((Glyph)moon.modItem).Randomize();
@@ -301,6 +301,9 @@ namespace kRPG
 
         public override void ModifyDrawLayers(List<PlayerLayer> layers)
         {
+			if(kRPG.overhaul!=null) {
+				return;
+			}
             for (int i = 0; i < layers.Count; i += 1)
             {
                 if (layers[i].Name.Contains("Held"))
@@ -1073,7 +1076,6 @@ namespace kRPG
                 for (int j = 0; j < inventories[i].Length; j += 1)
                 {
                     inventories[i][j] = new Item();
-                    inventories[i][j].SetDefaults();
                 }
             }
 
@@ -1087,7 +1089,6 @@ namespace kRPG
                 for (int j = 0; j < abilities[i].glyphs.Length; j += 1)
                 {
                     abilities[i].glyphs[j] = new Item();
-                    abilities[i].glyphs[j].SetDefaults();
                 }
             }
             abilities[0].key = Keys.Z;
@@ -1120,6 +1121,10 @@ namespace kRPG
         public override void OnEnterWorld(Player player)
         {
             InitializeGUI();
+
+			if(player.whoAmI==Main.myPlayer) {
+				kRPG.CheckForUpdates();
+			}
         }
 
         public override TagCompound Save()

--- a/kRPG/Projectiles/ProceduralProjectile.cs
+++ b/kRPG/Projectiles/ProceduralProjectile.cs
@@ -107,9 +107,9 @@ namespace kRPG.Projectiles
             if (source == null)
             {
                 source = new ProceduralSpell(mod);
-                source.glyphs[(byte)GLYPHTYPE.STAR].SetDefaults(startype);
-                source.glyphs[(byte)GLYPHTYPE.CROSS].SetDefaults(crosstype);
-                source.glyphs[(byte)GLYPHTYPE.MOON].SetDefaults(moontype);
+                source.glyphs[(byte)GLYPHTYPE.STAR].SetDefaults(startype,true);
+                source.glyphs[(byte)GLYPHTYPE.CROSS].SetDefaults(crosstype,true);
+                source.glyphs[(byte)GLYPHTYPE.MOON].SetDefaults(moontype,true);
                 source.modifierOverride = modifiers;
             }
             foreach (Item item in source.glyphs)

--- a/kRPG/build.txt
+++ b/kRPG/build.txt
@@ -7,3 +7,4 @@ includeSource = true
 buildIgnore = *.csproj, *.user, obj\*, bin\*, .vs\*
 includePDB = true
 weakReferences = TerrariaOverhaul, MagicStorage
+languageVersion = 6

--- a/kRPG/kConfig.cs
+++ b/kRPG/kConfig.cs
@@ -13,15 +13,9 @@ namespace kRPG
 {
     public class kConfig
     {
-        public static ClientConfig clientside
-        {
-            get
-            {
-                return configLocal.clientside;
-            }
-        }
-        public static string configName = "kRPG_Settings.json";
-        public static string configPath;
+        public static ClientConfig clientside	=> configLocal.clientside;
+		public static string configPath			=> Main.SavePath+Path.DirectorySeparatorChar+"kRPG_Settings.json";
+		public static string statsPath			=> Main.SavePath+Path.DirectorySeparatorChar+"kRPG_Stats.json";
 
         //Make this fancier?
         internal static Config _configLocal = new Config();
@@ -57,17 +51,26 @@ namespace kRPG
                 _configServer = value;
             }
         }
+		internal static ConfigStats _stats=	new ConfigStats();
+		public static ConfigStats stats {
+			get {
+				if(_stats==null) {
+					_stats=	new ConfigStats();
+					LoadConfig(statsPath,ref _stats);
+				}
+				return _stats;
+			}
+			private set {
+				_stats=	value;
+			}
+		}
 
         public static void Initialize()
         {
             try
             {
-                configPath = string.Concat(new object[] {
-                    Main.SavePath,
-                    Path.DirectorySeparatorChar,
-                    configName,
-                });
                 configLocal = new Config();
+				stats = new ConfigStats();
                 Load();
             }
             catch (SystemException e)
@@ -84,6 +87,10 @@ namespace kRPG
                 _configLocal = new Config();
                 LoadConfig(configPath, ref _configLocal);
                 Save();
+
+				_stats = new ConfigStats();
+				LoadConfig(statsPath,ref _stats);
+				SaveStats();
             }
             catch (SystemException e)
             {
@@ -119,6 +126,11 @@ namespace kRPG
                 ErrorLogger.Log(e.ToString());
             }
         }
+		public static void SaveStats()
+		{
+			Directory.CreateDirectory(Main.SavePath);
+			File.WriteAllText(statsPath,JsonConvert.SerializeObject(stats,Formatting.Indented).Replace("  ","\t"));
+		}
         
         public class ClientConfig
         {
@@ -130,5 +142,9 @@ namespace kRPG
         {
             public ClientConfig clientside = new ClientConfig();
         }
+		public class ConfigStats
+		{
+			public string lastStartVersion=		"1.1.1";
+		}
     }
 }


### PR DESCRIPTION
Enabled C# 6, improved MP performance from about 5 to 60 fps, added checks for updates. Somewhat improved overhaul compatibility, but currently with overhaul 2.0.2 none of the procedural items are overhauled, because of a flaw on overhaul's side. However, after fixing it on overhaul's side there's some issues with procedural swords receiving "spear" tag for some reason. Weirdness. Kalci, you better move spears to a new class.